### PR TITLE
Create modulescanner.csv while walking the target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target/
 .DS_Store
+modulescanner.csv

--- a/src/main/java/org/adoptopenjdk/modulescanner/CsvPrinter.java
+++ b/src/main/java/org/adoptopenjdk/modulescanner/CsvPrinter.java
@@ -1,0 +1,66 @@
+package org.adoptopenjdk.modulescanner;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.adoptopenjdk.modulescanner.MavenRepoWalker.MavenArtifact;
+import org.adoptopenjdk.modulescanner.ModuleInspector.ModuleInspectResult;
+
+class CsvPrinter {
+
+	private final PrintWriter out;
+	private final String delimiter;
+	private final AtomicInteger lineCounter;
+
+	CsvPrinter(PrintWriter out, String delimiter) {
+		this.out = out;
+		this.delimiter = delimiter;
+		this.lineCounter = new AtomicInteger();
+	}
+
+	int getLineCount() {
+		return lineCounter.get();
+	}
+
+	// Create CSV header as string
+	// Note: Keep in sync with #generateLine
+	private String generateHeaderLine() {
+		var columns = List.of(
+				"groupId",
+				"artifactId",
+				"version",
+				"moduleName",
+				"moduleVersion",
+				"moduleMode",
+				"moduleDependencies");
+		return String.join(delimiter, columns);
+	}
+
+	// Create single CSV line from artifact and module inspection result
+	// Note: Keep in sync with #generateHeaderLine
+	private String generateLine(MavenArtifact artifact, ModuleInspectResult mir) {
+		var columns = List.of(
+				valueOrDashIfBlank(artifact.groupId),
+				valueOrDashIfBlank(artifact.artifactId),
+				valueOrDashIfBlank(artifact.version),
+				valueOrDashIfBlank(mir.moduleName),
+				valueOrDashIfBlank(mir.moduleVersion),
+				mir.isAutomaticModule ? "automatic" : mir.isExplicitModule ? "explicit" : "-",
+				valueOrDashIfBlank(String.join(" + ", mir.dependencies)));
+		return String.join(delimiter, columns);
+	}
+
+	// Convert null or blank values to "-".
+	private static String valueOrDashIfBlank(String value) {
+		return (value == null || value.trim().isEmpty() ) ? "-" : value;
+	}
+
+	void printHeaderLine() {
+		out.println(generateHeaderLine());
+	}
+
+	void printAndCountLine(MavenArtifact artifact, ModuleInspectResult mir) {
+		out.println(generateLine(artifact, mir));
+		lineCounter.incrementAndGet();
+	}
+}

--- a/src/main/java/org/adoptopenjdk/modulescanner/Main.java
+++ b/src/main/java/org/adoptopenjdk/modulescanner/Main.java
@@ -34,7 +34,7 @@ public class Main {
      *
      * @param args Commandline arguments
      */
-    public static void main(String[] args) {
+    public static void main(String... args) {
         var directoryToScan = Paths.get(args.length > 0 ? args[0] : DEFAULT_DIRECTORY_TO_SCAN);
         var cutoffDate = args.length > 1 ? args[1] : CUTOFF_DATE;
         var outputFileName = args.length > 2 ? args[2] : DEFAULT_OUTPUT_FILE_NAME;

--- a/src/main/java/org/adoptopenjdk/modulescanner/Main.java
+++ b/src/main/java/org/adoptopenjdk/modulescanner/Main.java
@@ -1,5 +1,12 @@
 package org.adoptopenjdk.modulescanner;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.util.List;
+import org.adoptopenjdk.modulescanner.MavenRepoWalker.MavenArtifact;
+import org.adoptopenjdk.modulescanner.ModuleInspector.ModuleInspectResult;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -19,6 +26,8 @@ public class Main {
 
     private static String DEFAULT_DIRECTORY_TO_SCAN = "../gs-maven-mirror";
     private static String CUTOFF_DATE = "20170101000000";
+    private static String DEFAULT_OUTPUT_FILE_NAME = "modulescanner.csv";
+    private static String DEFAULT_OUTPUT_DELIMITER = ", ";
 
     /**
      * Main method - entry point for invoking modulescanner
@@ -28,16 +37,31 @@ public class Main {
     public static void main(String[] args) {
         var directoryToScan = Paths.get(args.length > 0 ? args[0] : DEFAULT_DIRECTORY_TO_SCAN);
         var cutoffDate = args.length > 1 ? args[1] : CUTOFF_DATE;
+        var outputFileName = args.length > 2 ? args[2] : DEFAULT_OUTPUT_FILE_NAME;
 
+        // walk(directoryToScan, cutoffDate, new PrintWriter(System.out));
+
+        try (var fw = new FileWriter(outputFileName); var bw = new BufferedWriter(fw); var out = new PrintWriter(bw)) {
+            walk(directoryToScan, cutoffDate, out);
+        } catch (IOException ioe) {
+            LOGGER.error("Walking directory: " + directoryToScan + " failed", ioe);
+            throw new UncheckedIOException("", ioe);
+        }
+    }
+
+    private static void walk(Path directoryToScan, String cutoffDate, PrintWriter out) {
+        out.println(toHead());
         new MavenRepoWalker(directoryToScan, cutoffDate).getArtifactsToInspect()
                 .forEach(artifact -> {
                     JarFile jarFile = toJarFile(artifact.path);
                     if (jarFile != null) {
-                        ModuleInspector.ModuleInspectResult moduleInspectorResult = new ModuleInspector(jarFile).inspect();
-                        JdepsInspector.JdepsInspectResult jdepsInspectorResult = new JdepsInspector(artifact.path).inspect();
+                        var moduleInspectorResult = new ModuleInspector(jarFile).inspect();
+                        var jdepsInspectorResult = new JdepsInspector(artifact.path).inspect();
                         LOGGER.info(artifact + "\n -> " + moduleInspectorResult + "\n -> " + jdepsInspectorResult);
+                        out.println(toLine(artifact, moduleInspectorResult));
                     }
                 });
+        out.flush();
     }
 
     // Convert a given Path to a Jar file for processing
@@ -50,4 +74,34 @@ public class Main {
         }
     }
 
+    // Create CSV header as string
+    private static String toHead() {
+        var columns = List.of(
+                "groupId",
+                "artifactId",
+                "version",
+                "moduleName",
+                "moduleVersion",
+                "moduleMode",
+                "moduleDependencies");
+        return String.join(DEFAULT_OUTPUT_DELIMITER, columns);
+    }
+
+    // Create single CSV line from artifact and module inspection result
+    private static String toLine(MavenArtifact artifact, ModuleInspectResult mir) {
+        var columns = List.of(
+                valueOrDashIfBlank(artifact.groupId),
+                valueOrDashIfBlank(artifact.artifactId),
+                valueOrDashIfBlank(artifact.version),
+                valueOrDashIfBlank(mir.moduleName),
+                valueOrDashIfBlank(mir.moduleVersion),
+                mir.isAutomaticModule ? "automatic" : mir.isExplicitModule ? "explicit" : "-",
+                valueOrDashIfBlank(String.join(" + ", mir.dependencies)));
+        return String.join(DEFAULT_OUTPUT_DELIMITER, columns);
+    }
+
+    // Convert null or blank values to "-".
+    private static String valueOrDashIfBlank(String value) {
+        return (value == null || value.trim().isEmpty() ) ? "-" : value;
+    }
 }

--- a/src/test/java/org/adoptopenjdk/modulescanner/MainTest.java
+++ b/src/test/java/org/adoptopenjdk/modulescanner/MainTest.java
@@ -1,0 +1,22 @@
+package org.adoptopenjdk.modulescanner;
+
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+class MainTest {
+
+    @Test
+    void testCsvOutput() throws Exception {
+        var testMavenRepo = Paths.get("src/test/resources/test-maven-repo");
+        var targetOutput = Paths.get("target/actual-modulescanner.csv");
+
+        Main.main(testMavenRepo.toString(), "20170101000000", targetOutput.toString());
+
+        var expectedLines = Files.readAllLines(testMavenRepo.resolve("expected-modulescanner.csv"));
+        var actualLines = Files.readAllLines(targetOutput);
+        assertLinesMatch(expectedLines, actualLines);
+    }
+}

--- a/src/test/java/org/adoptopenjdk/modulescanner/MainTest.java
+++ b/src/test/java/org/adoptopenjdk/modulescanner/MainTest.java
@@ -11,7 +11,7 @@ class MainTest {
     @Test
     void testCsvOutput() throws Exception {
         var testMavenRepo = Paths.get("src/test/resources/test-maven-repo");
-        var targetOutput = Paths.get("target/actual-modulescanner.csv");
+        var targetOutput = Files.createTempFile("actual-", "-modulescanner.csv");
 
         Main.main(testMavenRepo.toString(), "20170101000000", targetOutput.toString());
 

--- a/src/test/resources/test-maven-repo/expected-modulescanner.csv
+++ b/src/test/resources/test-maven-repo/expected-modulescanner.csv
@@ -1,3 +1,3 @@
-groupId, artifactId, version, moduleName, moduleVersion, moduleMode, moduleDependencies
-com.fasterxml.jackson.core, jackson-core, 2.9.6, com.fasterxml.jackson.core, -, automatic, -
-org.slf4j, slf4j-api, 1.8.0-beta2, org.slf4j, -, explicit, java.base
+groupId,artifactId,version,moduleName,moduleVersion,moduleMode,moduleDependencies,jdepsToolError,jdepsViolations
+com.fasterxml.jackson.core,jackson-core,2.9.6,com.fasterxml.jackson.core,-,automatic,-,false,-
+org.slf4j,slf4j-api,1.8.0-beta2,org.slf4j,-,explicit,java.base,false,-

--- a/src/test/resources/test-maven-repo/expected-modulescanner.csv
+++ b/src/test/resources/test-maven-repo/expected-modulescanner.csv
@@ -1,0 +1,3 @@
+groupId, artifactId, version, moduleName, moduleVersion, moduleMode, moduleDependencies
+com.fasterxml.jackson.core, jackson-core, 2.9.6, com.fasterxml.jackson.core, -, automatic, -
+org.slf4j, slf4j-api, 1.8.0-beta2, org.slf4j, -, explicit, java.base


### PR DESCRIPTION
Produces `modulescanner.csv` file:

```csv
groupId,artifactId,version,moduleName,moduleVersion,moduleMode,moduleDependencies,jdepsToolError,jdepsViolations
com.fasterxml.jackson.core,jackson-core,2.9.6,com.fasterxml.jackson.core,-,automatic,-,false,-
org.slf4j,slf4j-api,1.8.0-beta2,org.slf4j,-,explicit,java.base,false,-
```